### PR TITLE
chore(env vars): add client supabase vars to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,9 @@ EXPOSE 3000
 
 ENV PORT=3000
 
+ENV NEXT_PUBLIC_SUPABASE_ANON_KEY undefined
+ENV NEXT_PUBLIC_SUPABASE_URL undefined
+
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output
 ENV HOSTNAME="0.0.0.0"


### PR DESCRIPTION
* coolify deployment has been changed such that the docker image is build on GitHub
* env vars are declared in coolify so best to keep them there
* thus env vars need to be available at runtime