### PR TITLE
chore(env vars): env vars in github actions instead

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -35,6 +35,9 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ vars.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
       - name: Deploy to Coolify
         run: |
           curl --request GET '${{ secrets.COOLIFY_WEBHOOK }}' --header 'Authorization: Bearer ${{ secrets.COOLIFY_TOKEN }}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,6 @@ EXPOSE 3000
 
 ENV PORT=3000
 
-ENV NEXT_PUBLIC_SUPABASE_ANON_KEY undefined
-ENV NEXT_PUBLIC_SUPABASE_URL undefined
-
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output
 ENV HOSTNAME="0.0.0.0"


### PR DESCRIPTION
* env vars flow through to the client browser so need to be part of the build process